### PR TITLE
fix fast_dtoa setting result to empty string for values larger than 0x7FFFFFFF

### DIFF
--- a/src/util/string_helper.cpp
+++ b/src/util/string_helper.cpp
@@ -436,12 +436,14 @@ namespace ardb
          */
         if (value > thres_max)
         {
-            while (snprintf(str, slen, "%e", neg ? -value : value) < 0)
+            int printed = snprintf(str, slen, "%e", neg ? -value : value);
+            while (printed < 0)
             {
                 slen *= 2;
                 str = (char*) realloc(str, slen);
+		printed = snprintf(str, slen, "%e", neg ? -value : value);
             }
-            result.assign(str, (wstr - str));
+            result.assign(str, printed);
             free(str);
             return;
         }


### PR DESCRIPTION
fast_dtoa, when given a value larger than 0x7FFFFFFF, could return an empty string. A specific number that demonstrates this is 1404769122248.5. The problem was that in this path, wstr is never updated so wstr-str is 0.
