### PR TITLE
adjust channel setsize to account for db's max open files

### DIFF
--- a/src/ardb_server.cpp
+++ b/src/ardb_server.cpp
@@ -900,7 +900,13 @@ namespace ardb
         }
         DBCrons::GetSingleton().Init(this);
 
-        m_service = new ChannelService(m_cfg.max_clients + 32);
+        int64 set_size_adjustment = 32;
+        if (m_engine.GetName() == "LevelDB" || m_engine.GetName() == "RocksDB")
+        {
+            set_size_adjustment += m_db->GetEngine()->MaxOpenFiles();
+        }
+
+        m_service = new ChannelService(m_cfg.max_clients + set_size_adjustment);
         m_service->SetThreadPoolSize(worker_count);
         ChannelOptions ops;
         ops.tcp_nodelay = true;

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -104,6 +104,10 @@ namespace ardb
             virtual ~KeyValueEngine()
             {
             }
+            virtual int MaxOpenFiles()
+            {
+                return 0;
+            }
     };
 
     class BatchWriteGuard

--- a/src/engine/leveldb_engine.cpp
+++ b/src/engine/leveldb_engine.cpp
@@ -364,6 +364,11 @@ namespace ardb
         return version_info + str;
     }
 
+    int LevelDBEngine::MaxOpenFiles()
+    {
+        return m_options.max_open_files;
+    }
+
     LevelDBIterator::~LevelDBIterator()
     {
         delete m_iter;

--- a/src/engine/leveldb_engine.hpp
+++ b/src/engine/leveldb_engine.hpp
@@ -179,6 +179,7 @@ namespace ardb
             const std::string Stats();
             void CompactRange(const Slice& begin, const Slice& end);
             void ReleaseContextSnapshot();
+            int MaxOpenFiles();
     };
 
     class LevelDBEngineFactory: public KeyValueEngineFactory

--- a/src/engine/rocksdb_engine.cpp
+++ b/src/engine/rocksdb_engine.cpp
@@ -363,6 +363,11 @@ namespace ardb
         return version_info + str;
     }
 
+    int LevelDBEngine::MaxOpenFiles()
+    {
+        return m_options.max_open_files;
+    }
+
     RocksDBIterator::~RocksDBIterator()
     {
         delete m_iter;

--- a/src/engine/rocksdb_engine.hpp
+++ b/src/engine/rocksdb_engine.hpp
@@ -182,6 +182,7 @@ namespace ardb
             const std::string Stats();
             void CompactRange(const Slice& begin, const Slice& end);
             void ReleaseContextSnapshot();
+            int MaxOpenFiles();
     };
 
     class RocksDBEngineFactory: public KeyValueEngineFactory


### PR DESCRIPTION
If leveldb.max_open_files is large and maxclients is small, then clients can fail to connect because the fd for their socket has a number larger than maxclients, even if only a single client is connecting. This adjusts the fd limits to take into account the number of files the db is allowed to have open.
