### PR TITLE
reenable cross compilation

### DIFF
--- a/src/command/t_list.cpp
+++ b/src/command/t_list.cpp
@@ -29,6 +29,7 @@
 
 #include "ardb.hpp"
 #include <float.h>
+#include <cmath>
 
 OP_NAMESPACE_BEGIN
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -98,7 +98,7 @@
 #define HAVE_TASKINFO 1
 #endif
 
-#if (__i386 || __amd64) && __GNUC__
+#if (__i386 || __amd64 || __arm__) && __GNUC__
 #define GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if GNUC_VERSION >= 40100
 #define HAVE_SYNC_OP


### PR DESCRIPTION
When I tried to move forward to the tip of ardb, I discovered that several changes made to support cross compilation had been undone. The bulk of these changes were already committed as part of commit 4b0b7d38682fa1610c40dd19cfbbe3015eb96a10. The one new change is `#include <cmath>` which solved a problem where `std::abs` was ambiguous for the compiler.
