### PR TITLE
Use standart Redis reply

### DIFF
--- a/src/command/lua_scripting.cpp
+++ b/src/command/lua_scripting.cpp
@@ -835,7 +835,7 @@ namespace ardb
             if (func.size() != 40)
             {
                 reply.type = REDIS_REPLY_ERROR;
-                reply.str = "-NOSCRIPT No matching script. Please use EVAL.";
+                reply.str = "NOSCRIPT No matching script. Please use EVAL.";
                 return -1;
             }
             funcname.append(func);
@@ -863,7 +863,7 @@ namespace ardb
                     lua_pop(m_lua, 1);
                     /* remove the error handler from the stack. */
                     reply.type = REDIS_REPLY_ERROR;
-                    reply.str = "-NOSCRIPT No matching script. Please use EVAL.";
+                    reply.str = "NOSCRIPT No matching script. Please use EVAL.";
                     return -1;
                 }
                 funptr = &cachedfunc;


### PR DESCRIPTION
This trivial change allows python and ruby redis clients to work correctly with ardb when using lua scripting feature.
Python (and Ruby) clients check response line if it starts with "NOSCRIPT" (not "-NOSCRIPT")