### PR TITLE
Fixed infinite loop during Ardb::ClearBlockKeys, which happened when …

### DIFF
--- a/src/command/t_list.cpp
+++ b/src/command/t_list.cpp
@@ -1086,6 +1086,7 @@ OP_NAMESPACE_BEGIN
                         m_block_context_table.erase(fit);
                     }
                 }
+                it++;
             }
             ctx.ClearBlockContext();
         }


### PR DESCRIPTION
Fixed infinite loop during Ardb::ClearBlockKeys, which happened when blpop/brpop/blpoprpush was called with positive timeout (even if client was disconnected) on empty/nonexisten key.

To reproduce do 
```
redis-cli blpop any_random_key 1000
>CTRL^C
```
It should go into infinite loop and cpu spikes to 90%-100%.

P.S. My c++ is a bit rusty, let me know if its totally wrong.