### PR TITLE
Fixed zremrangebyscore returning empty list/set when key does not exist

### DIFF
--- a/src/command/t_zset.cpp
+++ b/src/command/t_zset.cpp
@@ -839,7 +839,14 @@ OP_NAMESPACE_BEGIN
         ValueObject meta;
         int err = GetMetaValue(ctx, cmd.GetArguments()[0], ZSET_META, meta);
         CHECK_ARDB_RETURN_VALUE(ctx.reply, err);
-        ctx.reply.type = REDIS_REPLY_ARRAY;
+        if (cmd.GetType() == REDIS_CMD_ZREMRANGEBYSCORE)
+        {
+            ctx.reply.type = REDIS_REPLY_INTEGER;
+        }
+        else
+        {
+            ctx.reply.type = REDIS_REPLY_ARRAY;
+        }
         if (0 != err)
         {
             return 0;


### PR DESCRIPTION
As per http://redis.io/commands/zremrangebyscore, zremrangebyscore always returns integer.
But ardb is returning "empty set/list" response when key does not exist.
(Breaks clients that expect int, for example redis-py crashes with TypeError trying to  convert empty list  -> int)