### PR TITLE
Fixed blocking client leaking connections/context [WIP]

### DIFF
--- a/src/ardb.cpp
+++ b/src/ardb.cpp
@@ -914,6 +914,14 @@ OP_NAMESPACE_BEGIN
 
     int Ardb::Call(Context& ctx, RedisCommandFrame& args, int flags)
     {
+        /*
+         * Ignore commands from blocked connection
+         */
+        if (NULL != ctx.block)
+        {
+            ctx.reply.type = 0;
+            return 0;
+        }
         RedisCommandHandlerSetting* found = FindRedisCommandHandlerSetting(args);
         if (NULL == found)
         {

--- a/src/command/t_list.cpp
+++ b/src/command/t_list.cpp
@@ -1125,11 +1125,15 @@ OP_NAMESPACE_BEGIN
         if (NULL != ctx.client)
         {
             ctx.client->DetachFD();
+            if (timeout > 0)
+            {
+                ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(
+                        new BlockConnectionTimeout(&ctx), timeout, -1, SECONDS);
+            }
         }
-        if (timeout > 0)
+        if (ctx.reply.type == REDIS_REPLY_NIL)
         {
-            ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(
-                    new BlockConnectionTimeout(&ctx), timeout, -1, SECONDS);
+            ctx.reply.type = 0;
         }
         return 0;
     }
@@ -1164,6 +1168,10 @@ OP_NAMESPACE_BEGIN
                 ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(
                         new BlockConnectionTimeout(&ctx), timeout, -1, SECONDS);
             }
+        }
+        if (ctx.reply.type == REDIS_REPLY_NIL)
+        {
+            ctx.reply.type = 0;
         }
         return 0;
     }

--- a/src/command/t_list.cpp
+++ b/src/command/t_list.cpp
@@ -534,7 +534,8 @@ OP_NAMESPACE_BEGIN
             }
             ch->Write(ctx->reply);
             g_db->ClearBlockKeys(*ctx);
-            ch->AttachFD();
+            // We do not detach fd anymore
+            // ch->AttachFD();
         }
     }
 
@@ -1125,7 +1126,8 @@ OP_NAMESPACE_BEGIN
         }
         if (NULL != ctx.client)
         {
-            ctx.client->DetachFD();
+            // Do not detach fd, otherwise connection is not cleared when client disconnects
+            // ctx.client->DetachFD();
             if (timeout > 0)
             {
                 ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(
@@ -1163,7 +1165,8 @@ OP_NAMESPACE_BEGIN
         }
         if (NULL != ctx.client)
         {
-            ctx.client->DetachFD();
+            // Do not detach fd, otherwise connection is not cleared when client disconnects
+            // ctx.client->DetachFD();
             if (timeout > 0)
             {
                 ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(
@@ -1187,11 +1190,11 @@ OP_NAMESPACE_BEGIN
         RPopLPush(ctx, cmd);
         if (ctx.reply.type == REDIS_REPLY_NIL)
         {
-            //block;
             AddBlockKey(ctx, cmd.GetArguments()[0]);
             if (NULL != ctx.client)
             {
-                ctx.client->DetachFD();
+                // Do not detach fd, otherwise connection is not cleared when client disconnects
+                // ctx.client->DetachFD();
                 if (timeout > 0)
                 {
                     ctx.block->blocking_timer_task_id = ctx.client->GetService().GetTimer().ScheduleHeapTask(

--- a/src/command/t_list.cpp
+++ b/src/command/t_list.cpp
@@ -1086,6 +1086,7 @@ OP_NAMESPACE_BEGIN
                         m_block_context_table.erase(fit);
                     }
                 }
+                it++;
             }
             ctx.ClearBlockContext();
         }


### PR DESCRIPTION
When blocking clients disconnects, ardb leaks its connection and context.
If blocking call had a positive timeout, due to timeout, it will actually wake up and clean it up, but if it was infinite, connection and context will stick around until restart.

```
root@723f861d1352:~/ardb-bin# redis-cli -p 16379 info clients
# Clients
connected_clients:1
blocked_clients:0

root@723f861d1352:~/ardb-bin# redis-cli -p 16379 blpop randomkey 0
^C
root@723f861d1352:~/ardb-bin# redis-cli -p 16379 info clients
# Clients
connected_clients:2
blocked_clients:1
```

When read FD is detached from the loop on blocking call, disconnect/connection error is not detected as it technically is recv() == 0, which never happens.

Redis buffers incoming commands while in blocked state, this pull req at the moment does not do it, but simply ignores incoming commands while blocked.