### PR TITLE
New snapshot type 'backup'

### DIFF
--- a/src/cluster/cluster.hpp
+++ b/src/cluster/cluster.hpp
@@ -36,10 +36,10 @@
 #include "thread/thread_mutex.hpp"
 #include "thread/lock_guard.hpp"
 #include "context.hpp"
-#include "rdb.hpp"
 #include "zookeeper.h"
 #include <map>
 #include <vector>
+#include "../repl/snapshot.hpp"
 
 OP_NAMESPACE_BEGIN
 

--- a/src/command/keys.cpp
+++ b/src/command/keys.cpp
@@ -26,8 +26,8 @@
  *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "../repl/snapshot.hpp"
 #include "db/db.hpp"
-#include "repl/rdb.hpp"
 
 OP_NAMESPACE_BEGIN
     int Ardb::ObjectLen(Context& ctx, KeyType type, const std::string& keystr)

--- a/src/command/migrate.cpp
+++ b/src/command/migrate.cpp
@@ -27,9 +27,9 @@
  *THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "../repl/snapshot.hpp"
 #include "db/db.hpp"
 #include "coro/coro_channel.hpp"
-#include "repl/rdb.hpp"
 
 OP_NAMESPACE_BEGIN
 

--- a/src/command/server.cpp
+++ b/src/command/server.cpp
@@ -1033,5 +1033,26 @@ namespace ardb
         return 0;
     }
 
+    int Ardb::Backup(Context& ctx, RedisCommandFrame& cmd)
+    {
+        RedisReply& reply = ctx.GetReply();
+        std::string dir = g_db->GetConf().backup_dir + "/" + g_engine_name + "_";
+        std::string postfix = "default";
+        if(cmd.GetArguments().size() > 0)
+        {
+            postfix = cmd.GetArguments()[0];
+        }
+        dir.append(postfix);
+        int err = m_engine->Backup(ctx, dir);
+        if(err != 0)
+        {
+            reply.SetErrCode(err);
+        }
+        else
+        {
+            reply.SetStatusCode(STATUS_OK);
+        }
+        return 0;
+    }
 }
 

--- a/src/command/server.cpp
+++ b/src/command/server.cpp
@@ -28,7 +28,6 @@
  */
 
 #include "db/db.hpp"
-#include "repl/rdb.hpp"
 #include "repl/repl.hpp"
 #include "util/socket_address.hpp"
 #include "util/lru.hpp"
@@ -39,6 +38,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#include "../repl/snapshot.hpp"
 
 namespace ardb
 {
@@ -56,9 +56,14 @@ namespace ardb
     {
         RedisReply& reply = ctx.GetReply();
         SnapshotType type = REDIS_DUMP;
-        if (cmd.GetType() == REDIS_CMD_SAVE2)
+        if(cmd.GetArguments().size() == 1)
         {
-            type = ARDB_DUMP;
+             type = Snapshot::GetSnapshotTypeByName(cmd.GetArguments()[0]);
+             if(type == -1)
+             {
+                 reply.SetErrCode(ERR_INVALID_ARGS);
+                 return 0;
+             }
         }
         ChannelService* io_serv = NULL;
         uint32 conn_id = 0;
@@ -98,9 +103,14 @@ namespace ardb
     {
         RedisReply& reply = ctx.GetReply();
         SnapshotType type = REDIS_DUMP;
-        if (cmd.GetType() == REDIS_CMD_BGSAVE2)
+        if(cmd.GetArguments().size() == 1)
         {
-            type = ARDB_DUMP;
+             type = Snapshot::GetSnapshotTypeByName(cmd.GetArguments()[0]);
+             if(type == -1)
+             {
+                 reply.SetErrCode(ERR_INVALID_ARGS);
+                 return 0;
+             }
         }
         Snapshot* snapshot = g_snapshot_manager->NewSnapshot(type, true, NULL, NULL);
         if (NULL != snapshot)

--- a/src/common/channel/channel.cpp
+++ b/src/common/channel/channel.cpp
@@ -607,6 +607,8 @@ void Channel::OnWrite()
 
         if (m_file_sending->file_rest_len == 0)
         {
+            close(m_file_sending->fd);
+            m_file_sending->fd = -1;
             if (NULL != m_file_sending->on_complete)
             {
                 IOCallback* cb = m_file_sending->on_complete;
@@ -702,6 +704,8 @@ bool Channel::DoClose(bool inDestructor)
 
     if (NULL != m_file_sending)
     {
+        close(m_file_sending->fd);
+        m_file_sending->fd = -1;
         if (NULL != m_file_sending->on_failure)
         {
             m_file_sending->on_failure(m_file_sending->data);

--- a/src/common/channel/codec/dir_sync_decoder.cpp
+++ b/src/common/channel/codec/dir_sync_decoder.cpp
@@ -1,0 +1,110 @@
+/*
+ *Copyright (c) 2013-2013, yinqiwen <yinqiwen@gmail.com>
+ *All rights reserved.
+ *
+ *Redistribution and use in source and binary forms, with or without
+ *modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ *THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ *BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ *THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "dir_sync_decoder.hpp"
+
+
+#define STATE_DIR_SYNC_WAITING_DIR_HEADER 0
+#define STATE_DIR_SYNC_WAITING_FILE_HEADER 1
+#define STATE_DIR_SYNC_WAITING_FILE_CONTENT 2
+
+namespace ardb
+{
+    namespace codec
+    {
+        bool DirSyncDecoder::Decode(ChannelHandlerContext& ctx, Channel* channel, Buffer& buffer, DirSyncStatus& s)
+        {
+            while (buffer.Readable())
+            {
+                switch (_state)
+                {
+                    case STATE_DIR_SYNC_WAITING_DIR_HEADER:
+                    {
+                        if (!BufferHelper::ReadFixInt64(buffer, _rest_file_num))
+                        {
+                            return false;
+                        }
+                        _state = STATE_DIR_SYNC_WAITING_FILE_HEADER;
+                        s.status = _state;
+                        continue;
+                    }
+                    case STATE_DIR_SYNC_WAITING_FILE_HEADER:
+                    {
+                        std::string file;
+                        if (!BufferHelper::ReadVarString(buffer, file) || !BufferHelper::ReadFixInt64(buffer, _current_file_rest_bytes))
+                        {
+                            return false;
+                        }
+                        if (-1 != _current_fd)
+                        {
+                            close(_current_fd);
+                            _current_fd = -1;
+                        }
+
+                        _state = STATE_DIR_SYNC_WAITING_FILE_CONTENT;
+                        s.status = _state;
+                        continue;
+                    }
+                    case STATE_DIR_SYNC_WAITING_FILE_CONTENT:
+                    {
+                        size_t write_len = _current_file_rest_bytes;
+                        if (buffer.ReadableBytes() < write_len)
+                        {
+                            write_len = buffer.ReadableBytes();
+                        }
+                        int n = write(_current_fd, (const void*) (buffer.GetRawReadBuffer()), write_len);
+                        if (n > 0)
+                        {
+                            _current_file_rest_bytes -= n;
+                            buffer.AdvanceReadIndex(n);
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                        if (0 == _current_file_rest_bytes)
+                        {
+                            close(_current_fd);
+                            _current_fd = -1;
+                            _state = STATE_DIR_SYNC_WAITING_FILE_HEADER;
+                            _rest_file_num--;
+                        }
+                        s.status = _state;
+                        continue;
+                    }
+                    default:
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}
+

--- a/src/common/channel/codec/dir_sync_decoder.cpp
+++ b/src/common/channel/codec/dir_sync_decoder.cpp
@@ -74,7 +74,7 @@ namespace ardb
                 {
                     case STATE_DIR_SYNC_WAITING_DIR_HEADER:
                     {
-                        while (buffer.Readable() && (buffer.GetRawReadBuffer()[0] == '\r' || buffer.GetRawReadBuffer()[0] == '\n'))
+                        while (buffer.Readable() &&  buffer.GetRawReadBuffer()[0] == '\n')
                         {
                             buffer.AdvanceReadIndex(1);
                         }

--- a/src/common/channel/codec/dir_sync_decoder.hpp
+++ b/src/common/channel/codec/dir_sync_decoder.hpp
@@ -1,0 +1,75 @@
+/*
+ *Copyright (c) 2013-2013, yinqiwen <yinqiwen@gmail.com>
+ *All rights reserved.
+ *
+ *Redistribution and use in source and binary forms, with or without
+ *modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of Redis nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ *THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ *BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ *THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef COMMON_CHANNEL_CODEC_DIR_SYNC_DECODER_HPP_
+#define COMMON_CHANNEL_CODEC_DIR_SYNC_DECODER_HPP_
+
+#include "channel/all_includes.hpp"
+#include "channel/codec/stack_frame_decoder.hpp"
+#include "buffer/buffer.hpp"
+
+using namespace ardb;
+using ardb::Buffer;
+namespace ardb
+{
+    namespace codec
+    {
+        struct DirSyncStatus
+        {
+                std::string path;
+                std::string reason;
+                int status;
+                int err;
+                DirSyncStatus() :
+                        status(0), err(0)
+                {
+                }
+        };
+        /*
+         * A dir sync decoder used to sync dir from remote server
+         */
+        class DirSyncDecoder: public StackFrameDecoder<DirSyncStatus>
+        {
+            private:
+                std::string _dir;
+                int _current_fd;
+                int64_t _current_file_rest_bytes;
+                int64_t _rest_file_num;
+                uint8 _state;
+                bool Decode(ChannelHandlerContext& ctx, Channel* channel, Buffer& buffer, DirSyncStatus& msg);
+            public:
+                DirSyncDecoder(const std::string& dir) :
+                        _dir(dir),_current_fd(0),_current_file_rest_bytes(0),_rest_file_num(0), _state(0)
+                {
+                }
+        };
+    }
+}
+
+#endif /* SRC_COMMON_CHANNEL_CODEC_DIR_SYNC_DECODER_HPP_ */

--- a/src/common/channel/codec/redis_command.hpp
+++ b/src/common/channel/codec/redis_command.hpp
@@ -255,8 +255,6 @@ namespace ardb
             REDIS_CMD_PEXPIRE2 = 1027,
             REDIS_CMD_SETBIT2 = 1028,
             REDIS_CMD_PFADD2 = 1029,
-            REDIS_CMD_BGSAVE2 = 1030,
-            REDIS_CMD_SAVE2 = 1031,
 
             REDIS_CMD_MAX = 1100,
         };

--- a/src/common/channel/codec/redis_command.hpp
+++ b/src/common/channel/codec/redis_command.hpp
@@ -83,6 +83,7 @@ namespace ardb
             REDIS_CMD_PUBSUB = 39,
             REDIS_CMD_MONITOR = 40,
             REDIS_CMD_DEBUG = 41,
+            REDIS_CMD_BACKUP = 42,
 
             //'keys' commands
             REDIS_CMD_DEL = 50,

--- a/src/common/channel/codec/redis_command_codec.cpp
+++ b/src/common/channel/codec/redis_command_codec.cpp
@@ -380,7 +380,7 @@ int RedisCommandDecoder::ProcessMultibulkBuffer(Channel* channel, Buffer& buffer
 
 bool RedisCommandDecoder::Decode(Channel* channel, Buffer& buffer, RedisCommandFrame& msg)
 {
-    while (buffer.GetRawReadBuffer()[0] == '\r' || buffer.GetRawReadBuffer()[0] == '\n')
+    while (buffer.Readable() && (buffer.GetRawReadBuffer()[0] == '\r' || buffer.GetRawReadBuffer()[0] == '\n'))
     {
         buffer.AdvanceReadIndex(1);
     }
@@ -425,7 +425,7 @@ bool RedisCommandDecoder::Decode(Channel* channel, Buffer& buffer, RedisCommandF
 bool RedisCommandDecoder::Decode(ChannelHandlerContext& ctx, Channel* channel, Buffer& buffer, RedisCommandFrame& msg)
 {
     bool have_empty = false;
-    while (buffer.GetRawReadBuffer()[0] == '\r' || buffer.GetRawReadBuffer()[0] == '\n')
+    while (buffer.Readable() && (buffer.GetRawReadBuffer()[0] == '\r' || buffer.GetRawReadBuffer()[0] == '\n'))
     {
         buffer.AdvanceReadIndex(1);
         have_empty = true;

--- a/src/common/channel/codec/redis_message_codec.hpp
+++ b/src/common/channel/codec/redis_message_codec.hpp
@@ -44,6 +44,7 @@
 #define REDIS_COMMAND_DECODER_TYPE 1
 #define REDIS_REPLY_DECODER_TYPE 2
 #define REDIS_DUMP_DECODER_TYPE 3
+#define ARDB_DIR_SYNC_DECODER_TYPE 4
 
 namespace ardb
 {
@@ -70,6 +71,10 @@ namespace ardb
                 bool IsDumpFile()
                 {
                     return type == REDIS_DUMP_DECODER_TYPE;
+                }
+                bool IsDirSync()
+                {
+                    return type == ARDB_DIR_SYNC_DECODER_TYPE;
                 }
         };
 

--- a/src/common/channel/codec/redis_reply_codec.cpp
+++ b/src/common/channel/codec/redis_reply_codec.cpp
@@ -255,9 +255,13 @@ bool RedisDumpFileChunkDecoder::Decode(ChannelHandlerContext& ctx, Channel* chan
 {
     if (m_waiting_chunk_len == 0)
     {
-        while (buffer.GetRawReadBuffer()[0] == '\n')
+        while (buffer.Readable() && buffer.GetRawReadBuffer()[0] == '\n')
         {
             buffer.AdvanceReadIndex(1);
+        }
+        if(!buffer.Readable())
+        {
+            return false;
         }
         int crlf_index = -1;
         crlf_index = buffer.IndexOf(kCRLF, 2);

--- a/src/common/util/file_helper.hpp
+++ b/src/common/util/file_helper.hpp
@@ -51,6 +51,7 @@ namespace ardb
 
     int list_subdirs(const std::string& path, std::deque<std::string>& dirs);
     int list_subfiles(const std::string& path, std::deque<std::string>& fs);
+    int list_allfiles(const std::string& path, std::deque<std::string>& fs);
 
     int64 file_size(const std::string& path);
 

--- a/src/db/db.cpp
+++ b/src/db/db.cpp
@@ -166,10 +166,8 @@ OP_NAMESPACE_BEGIN
         { "publish", REDIS_CMD_PUBLISH, &Ardb::Publish, 2, 2, "pltrF", 0, 0, 0 },
         { "pubsub", REDIS_CMD_PUBSUB, &Ardb::Pubsub, 1, -1, "pltrF", 0, 0, 0 },
         { "info", REDIS_CMD_INFO, &Ardb::Info, 0, 1, "rlt", 0, 0, 0 },
-        { "save", REDIS_CMD_SAVE, &Ardb::Save, 0, 0, "ars", 0, 0, 0 },
-        { "save2", REDIS_CMD_SAVE2, &Ardb::Save, 0, 0, "ars", 0, 0, 0 },
-        { "bgsave", REDIS_CMD_BGSAVE, &Ardb::BGSave, 0, 0, "ar", 0, 0, 0 },
-        { "bgsave2", REDIS_CMD_BGSAVE2, &Ardb::BGSave, 0, 0, "ar", 0, 0, 0 },
+        { "save", REDIS_CMD_SAVE, &Ardb::Save, 0, 1, "ars", 0, 0, 0 },
+        { "bgsave", REDIS_CMD_BGSAVE, &Ardb::BGSave, 0, 1, "ar", 0, 0, 0 },
         { "import", REDIS_CMD_IMPORT, &Ardb::Import, 1, 1, "aws", 0, 0, 0 },
         { "lastsave", REDIS_CMD_LASTSAVE, &Ardb::LastSave, 0, 0, "r", 0, 0, 0 },
         { "slowlog", REDIS_CMD_SLOWLOG, &Ardb::SlowLog, 1, 2, "r", 0, 0, 0 },
@@ -187,7 +185,7 @@ OP_NAMESPACE_BEGIN
         { "slaveof", REDIS_CMD_SLAVEOF, &Ardb::Slaveof, 2, -1, "ast", 0, 0, 0 },
         { "replconf", REDIS_CMD_REPLCONF, &Ardb::ReplConf, 0, -1, "arslt", 0, 0, 0 },
         { "sync", REDIS_CMD_SYNC, &Ardb::Sync, 0, 2, "ars", 0, 0, 0 },
-        { "psync", REDIS_CMD_PSYNC, &Ardb::PSync, 2, 4, "ars", 0, 0, 0 },
+        { "psync", REDIS_CMD_PSYNC, &Ardb::PSync, 2, -1, "ars", 0, 0, 0 },
         { "select", REDIS_CMD_SELECT, &Ardb::Select, 1, 1, "r", 0, 0, 0 },
         { "append", REDIS_CMD_APPEND, &Ardb::Append, 2, 2, "w", 0, 0, 0 },
         { "append2", REDIS_CMD_APPEND2, &Ardb::Append, 2, 2, "w", 0, 0, 0 },
@@ -511,6 +509,7 @@ OP_NAMESPACE_BEGIN
             std::string content = tmp;
             file_write_content(m_conf.pidfile, content);
         }
+        chdir(GetConf().home.c_str());
         ArdbLogger::InitDefaultLogger(m_conf.loglevel, m_conf.logfile);
 
         std::string dbdir = GetConf().data_base_path + "/" + g_engine_name;

--- a/src/db/db.cpp
+++ b/src/db/db.cpp
@@ -342,7 +342,8 @@ OP_NAMESPACE_BEGIN
         { "restorechunk", REDIS_CMD_RESTORECHUNK, &Ardb::RestoreChunk, 1, 1, "wl", 0, 0, 0 },
         { "restoredb", REDIS_CMD_RESTOREDB, &Ardb::RestoreDB, 1, 1, "wl", 0, 0, 0 },
         { "monitor", REDIS_CMD_MONITOR, &Ardb::Monitor, 0, 0, "ars", 0, 0, 0 },
-        { "debug", REDIS_CMD_DEBUG, &Ardb::Debug, 2, -1, "ars", 0, 0, 0 },};
+        { "debug", REDIS_CMD_DEBUG, &Ardb::Debug, 2, -1, "ars", 0, 0, 0 },
+        { "backup", REDIS_CMD_BACKUP, &Ardb::Backup, 0, 1, "ars", 0, 0, 0 },};
 
         CostRanges cmdstat_ranges;
         cmdstat_ranges.push_back(CostRange(0, 1000));

--- a/src/db/db.hpp
+++ b/src/db/db.hpp
@@ -440,6 +440,8 @@ OP_NAMESPACE_BEGIN
             int RestoreChunk(Context& ctx, RedisCommandFrame& cmd);
             int Debug(Context& ctx, RedisCommandFrame& cmd);
 
+            int Backup(Context& ctx, RedisCommandFrame& cmd);
+
             int DoCall(Context& ctx, RedisCommandHandlerSetting& setting, RedisCommandFrame& cmd);
             RedisCommandHandlerSetting* FindRedisCommandHandlerSetting(RedisCommandFrame& cmd);
             void RenameCommand();

--- a/src/db/engine.hpp
+++ b/src/db/engine.hpp
@@ -57,7 +57,7 @@ OP_NAMESPACE_BEGIN
              * Delete key/value pair at current iterator position.
              * It's more efficient, and the only right way to delete data in iterator for some engine(forestdb).
              */
-            virtual void Del()  = 0;
+            virtual void Del() = 0;
             virtual ~Iterator()
             {
             }
@@ -68,8 +68,9 @@ OP_NAMESPACE_BEGIN
             unsigned support_namespace :1;
             unsigned support_compactfilter :1;
             unsigned support_merge :1;
+            unsigned support_backup :1;
             FeatureSet() :
-                    support_namespace(0), support_compactfilter(0),support_merge(0)
+                    support_namespace(0), support_compactfilter(0), support_merge(0),support_backup(0)
             {
             }
     };
@@ -116,6 +117,15 @@ OP_NAMESPACE_BEGIN
             }
 
             virtual int EndBulkLoad(Context& ctx)
+            {
+                return ERR_NOTSUPPORTED;
+            }
+
+            virtual int Backup(Context& ctx, const std::string& dir)
+            {
+                return ERR_NOTSUPPORTED;
+            }
+            virtual int Restore(Context& ctx, const std::string& dir)
             {
                 return ERR_NOTSUPPORTED;
             }

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -680,7 +680,8 @@ OP_NAMESPACE_BEGIN
         rocksdb::Status s = rocksdb::BackupEngine::Open(rocksdb::Env::Default(), opt, &backup_engine);
         if (s.ok())
         {
-            s = backup_engine->CreateNewBackup(m_db);
+
+            s = backup_engine->CreateNewBackup(m_db, true);
             if(s.ok())
             {
                 backup_engine->PurgeOldBackups(1);

--- a/src/db/rocksdb/rocksdb_engine.hpp
+++ b/src/db/rocksdb/rocksdb_engine.hpp
@@ -151,6 +151,7 @@ OP_NAMESPACE_BEGIN
                 features.support_compactfilter = 1;
                 features.support_namespace = 1;
                 features.support_merge = 1;
+                features.support_backup = 1;
                 return features;
             }
     };

--- a/src/db/rocksdb/rocksdb_engine.hpp
+++ b/src/db/rocksdb/rocksdb_engine.hpp
@@ -32,6 +32,7 @@
 
 #include "common/common.hpp"
 #include "thread/spin_rwlock.hpp"
+#include "thread/thread_mutex.hpp"
 #include "thread/thread_local.hpp"
 #include "rocksdb/db.h"
 #include "rocksdb/write_batch.h"
@@ -40,6 +41,7 @@
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/statistics.h"
 #include "rocksdb/merge_operator.h"
+#include "rocksdb/utilities/backupable_db.h"
 #include "db/engine.hpp"
 #include <vector>
 #include <sparsehash/dense_hash_map>
@@ -100,10 +102,12 @@ OP_NAMESPACE_BEGIN
             typedef TreeMap<Data, ColumnFamilyHandlePtr>::Type ColumnFamilyHandleTable;
             typedef TreeMap<uint32_t, Data>::Type ColumnFamilyHandleIDTable;
             rocksdb::DB* m_db;
+
             rocksdb::Options m_options;
             std::string m_dbdir;
             ColumnFamilyHandleTable m_handlers;
             SpinRWLock m_lock;
+            ThreadMutex m_backup_lock;
 
             ColumnFamilyHandlePtr GetColumnFamilyHandle(Context& ctx, const Data& name, bool create_if_noexist);
             const rocksdb::Snapshot* GetSnpashot();
@@ -139,6 +143,8 @@ OP_NAMESPACE_BEGIN
             int BeginBulkLoad(Context& ctx);
             int EndBulkLoad(Context& ctx);
             const std::string GetErrorReason(int err);
+            int Backup(Context& ctx, const std::string& dir);
+            int Restore(Context& ctx, const std::string& dir);
             const FeatureSet GetFeatureSet()
             {
                 FeatureSet features;

--- a/src/repl/master.cpp
+++ b/src/repl/master.cpp
@@ -287,7 +287,6 @@ OP_NAMESPACE_BEGIN
             //send dir
             std::deque<std::string> fs;
             list_allfiles(dump_file_path, fs);
-
         }
 
         SendFileSetting setting;

--- a/src/repl/master.cpp
+++ b/src/repl/master.cpp
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include "db/db.hpp"
+#include "util/file_helper.hpp"
 
 #define MAX_SEND_CACHE_SIZE 8192
 
@@ -275,13 +276,20 @@ OP_NAMESPACE_BEGIN
         slave->repldbfd = -1;
         slave->snapshot = NULL;
         WARN_LOG("Send snapshot to slave:%s failed.", slave->GetAddress().c_str());
-        //g_repl->GetMaster().CloseSlave(slave);
     }
 
     void Master::SendSnapshotToSlave(SlaveSyncContext* slave)
     {
         slave->state = SYNC_STATE_SYNCING_SNAPSHOT;
         std::string dump_file_path = slave->snapshot->GetPath();
+        if(slave->snapshot->GetType() == BACKUP_DUMP)
+        {
+            //send dir
+            std::deque<std::string> fs;
+            list_allfiles(dump_file_path, fs);
+
+        }
+
         SendFileSetting setting;
         setting.fd = open(dump_file_path.c_str(), O_RDONLY);
         if (-1 == setting.fd)

--- a/src/repl/master.cpp
+++ b/src/repl/master.cpp
@@ -46,6 +46,7 @@ OP_NAMESPACE_BEGIN
             Snapshot* snapshot;
             Channel* conn;
             std::string repl_key;
+            std::string engine;
             int64 sync_offset;
             int64 ack_offset;
             uint64 sync_cksm;
@@ -55,7 +56,8 @@ OP_NAMESPACE_BEGIN
             bool isRedisSlave;
             uint8 state;
             SlaveSyncContext() :
-                    snapshot(NULL), conn(NULL), sync_offset(0), ack_offset(0), sync_cksm(0), acktime(0), port(0), repldbfd(-1), isRedisSlave(false), state(SYNC_STATE_INVALID)
+                    snapshot(NULL), conn(NULL), sync_offset(0), ack_offset(0), sync_cksm(0), acktime(0), port(0), repldbfd(-1), isRedisSlave(false), state(
+                            SYNC_STATE_INVALID)
             {
             }
             std::string GetAddress()
@@ -78,7 +80,8 @@ OP_NAMESPACE_BEGIN
     };
 
     Master::Master() :
-            m_repl_noslaves_since(0), m_repl_nolag_since(0), m_repl_good_slaves_count(0), m_slaves_count(0), m_sync_full_count(0), m_sync_partial_ok_count(0), m_sync_partial_err_count(0)
+            m_repl_noslaves_since(0), m_repl_nolag_since(0), m_repl_good_slaves_count(0), m_slaves_count(0), m_sync_full_count(0), m_sync_partial_ok_count(0), m_sync_partial_err_count(
+                    0)
     {
     }
 
@@ -217,7 +220,7 @@ OP_NAMESPACE_BEGIN
             {
                 return false;
             }
-            if(slave->sync_offset < g_repl->GetReplLog().WALEndOffset() - g_db->GetConf().repl_backlog_cache_size / 2)
+            if (slave->sync_offset < g_repl->GetReplLog().WALEndOffset() - g_db->GetConf().repl_backlog_cache_size / 2)
             {
                 return false;
             }
@@ -278,19 +281,6 @@ OP_NAMESPACE_BEGIN
     void Master::SendSnapshotToSlave(SlaveSyncContext* slave)
     {
         slave->state = SYNC_STATE_SYNCING_SNAPSHOT;
-//        //FULLRESYNC
-//        Buffer msg;
-//        slave->sync_offset = slave->snapshot->CachedReplOffset();
-//        slave->sync_cksm = slave->snapshot->CachedReplCksm();
-//        if (slave->isRedisSlave)
-//        {
-//            msg.Printf("+FULLRESYNC %s %lld\r\n", g_repl->GetReplLog().GetReplKey().c_str(), slave->sync_offset);
-//        }
-//        else
-//        {
-//            msg.Printf("+FULLRESYNC %s %lld %llu\r\n", g_repl->GetReplLog().GetReplKey().c_str(), slave->sync_offset, slave->sync_cksm);
-//        }
-//        slave->conn->Write(msg);
         std::string dump_file_path = slave->snapshot->GetPath();
         SendFileSetting setting;
         setting.fd = open(dump_file_path.c_str(), O_RDONLY);
@@ -337,7 +327,8 @@ OP_NAMESPACE_BEGIN
     {
         if (slave->sync_offset < g_repl->GetReplLog().WALStartOffset() || slave->sync_offset > g_repl->GetReplLog().WALEndOffset())
         {
-            WARN_LOG("Slave synced offset:%llu is invalid in offset range[%llu-%llu] for wal.", slave->sync_offset, g_repl->GetReplLog().WALStartOffset(), g_repl->GetReplLog().WALEndOffset());
+            WARN_LOG("Slave synced offset:%llu is invalid in offset range[%llu-%llu] for wal.", slave->sync_offset, g_repl->GetReplLog().WALStartOffset(),
+                    g_repl->GetReplLog().WALEndOffset());
             slave->conn->Close();
             return;
         }
@@ -429,10 +420,16 @@ OP_NAMESPACE_BEGIN
                     m_sync_partial_err_count++;
                 }
 
-                WARN_LOG("Create snapshot for full resync for slave replid:%s offset:%llu cksm:%llu, while current WAL runid:%s offset:%llu cksm:%llu", slave->repl_key.c_str(), slave->sync_offset, slave->sync_cksm,
-                        g_repl->GetReplLog().GetReplKey().c_str(), g_repl->GetReplLog().WALEndOffset(), g_repl->GetReplLog().WALCksm());
+                WARN_LOG("Create snapshot for full resync for slave replid:%s offset:%llu cksm:%llu, while current WAL runid:%s offset:%llu cksm:%llu",
+                        slave->repl_key.c_str(), slave->sync_offset, slave->sync_cksm, g_repl->GetReplLog().GetReplKey().c_str(),
+                        g_repl->GetReplLog().WALEndOffset(), g_repl->GetReplLog().WALCksm());
                 slave->state = SYNC_STATE_WAITING_SNAPSHOT;
-                slave->snapshot = g_snapshot_manager->GetSyncSnapshot(slave->isRedisSlave ? REDIS_DUMP : ARDB_DUMP, snapshot_dump_routine, this);
+                SnapshotType snapshot_type = slave->isRedisSlave ? REDIS_DUMP : ARDB_DUMP;
+                if(slave->engine == g_engine_name && g_engine->GetFeatureSet().support_backup)
+                {
+                    snapshot_type = BACKUP_DUMP;
+                }
+                slave->snapshot = g_snapshot_manager->GetSyncSnapshot(snapshot_type, snapshot_dump_routine, this);
                 if (NULL != slave->snapshot)
                 {
                     //FULLRESYNC
@@ -604,6 +601,10 @@ OP_NAMESPACE_BEGIN
                         return;
                     }
                 }
+                else if (cmd.GetArguments()[i] == "engine")
+                {
+                    ctx.engine = cmd.GetArguments()[i + 1];
+                }
             }
             if (ctx.isRedisSlave)
             {
@@ -689,8 +690,8 @@ OP_NAMESPACE_BEGIN
 
             uint32 lag = time(NULL) - slave->acktime;
             sprintf(buffer, "slave%u:%s,state=%s,"
-                    "offset=%" PRId64 ",ack_offset=%" PRId64",lag=%u,o_buffer_size=%u,o_buffer_capacity=%u\r\n", i, slave->GetAddress().c_str(), state, slave->sync_offset, slave->ack_offset, lag, slave->conn->WritableBytes(),
-                    slave->conn->GetOutputBuffer().Capacity());
+                    "offset=%" PRId64 ",ack_offset=%" PRId64",lag=%u,o_buffer_size=%u,o_buffer_capacity=%u\r\n", i, slave->GetAddress().c_str(), state,
+                    slave->sync_offset, slave->ack_offset, lag, slave->conn->WritableBytes(), slave->conn->GetOutputBuffer().Capacity());
             it++;
             i++;
             str.append(buffer);

--- a/src/repl/master.cpp
+++ b/src/repl/master.cpp
@@ -301,7 +301,7 @@ OP_NAMESPACE_BEGIN
             fstat(setting.fd, &st);
             Buffer header;
             BufferHelper::WriteVarString(header, fs);
-            BufferHelper::WriteFixInt64(header, (int64_t) st.st_size);
+            BufferHelper::WriteFixInt64(header, (int64_t) (st.st_size));
             slave->conn->Write(header);
 
             setting.file_rest_len = st.st_size;
@@ -344,7 +344,9 @@ OP_NAMESPACE_BEGIN
             slave->sync_backup_fs.clear();
             list_allfiles(dump_file_path, slave->sync_backup_fs);
             Buffer header;
-            BufferHelper::WriteFixInt64(header, (int64_t) slave->sync_backup_fs.size());
+            int64_t filenum = slave->sync_backup_fs.size();
+            header.Printf("#");  //start char
+            BufferHelper::WriteFixInt64(header, filenum);
             slave->conn->Write(header);
             return SendBackupToSlave(slave);
         }

--- a/src/repl/rdb.cpp
+++ b/src/repl/rdb.cpp
@@ -129,6 +129,21 @@ namespace ardb
     static const uint32 kloading_process_events_interval_bytes = 10 * 1024 * 1024;
     static const uint32 kmax_read_buffer_size = 10 * 1024 * 1024;
 
+    static const char* type2str(int type)
+    {
+        switch (type)
+        {
+            case ARDB_DUMP:
+                return "ardb";
+            case REDIS_DUMP:
+                return "redis";
+            case BACKUP_DUMP:
+                return "backup";
+            default:
+                return "unknown";
+        }
+    }
+
     static int EncodeInteger(long long value, unsigned char *enc)
     {
         /* Finally check if it fits in our ranges */
@@ -782,7 +797,7 @@ namespace ardb
     void ObjectIO::RedisLoadHashZipList(Context& ctx, unsigned char* data, const std::string& key, ValueObject& meta_value)
     {
         meta_value.SetType(KEY_HASH);
-        meta_value.SetObjectLen(ziplistLen(data)/2);
+        meta_value.SetObjectLen(ziplistLen(data) / 2);
         //BatchWriteGuard guard(g_db->GetKeyValueEngine());
         unsigned char* iter = ziplistIndex(data, 0);
         while (iter != NULL)
@@ -1631,26 +1646,45 @@ namespace ardb
             m_routine_cb(LOAD_START, this, m_routine_cbdata);
         }
         uint64_t start_time = get_current_epoch_millis();
-        bool is_redis_snapshot = IsRedisDumpFile(file);
-        ret = OpenReadFile(file);
-        if (0 != ret)
+        m_type = GetSnapshotType(file);
+        if (m_type == -1)
         {
-            return ret;
+            ERROR_LOG("Invalid snapshot file:%s", file.c_str());
+            return -1;
         }
-        if (is_redis_snapshot)
+        if (m_type != BACKUP_DUMP)
         {
-            m_type = REDIS_DUMP;
-            ret = RedisLoad();
+            ret = OpenReadFile(file);
+            if (0 != ret)
+            {
+                return ret;
+            }
         }
         else
         {
-            m_type = ARDB_DUMP;
+            m_file_path = file;
+        }
+
+        if (m_type == REDIS_DUMP)
+        {
+            ret = RedisLoad();
+        }
+        else if (m_type == ARDB_DUMP)
+        {
             ret = ArdbLoad();
+        }
+        else if (m_type == BACKUP_DUMP)
+        {
+            ret = BackupLoad();
+        }
+        else
+        {
+            ret = -1;
         }
         if (ret == 0)
         {
             uint64_t cost = get_current_epoch_millis() - start_time;
-            INFO_LOG("Cost %.2fs to load snapshot file with type:%s.", cost / 1000.0, is_redis_snapshot ? "redis" : "ardb");
+            INFO_LOG("Cost %.2fs to load snapshot file with type:%s.", cost / 1000.0, type2str(m_type));
         }
         m_state = ret == 0 ? LOAD_SUCCESS : LOAD_FAIL;
         if (NULL != m_routine_cb)
@@ -1758,11 +1792,23 @@ namespace ardb
 
     int Snapshot::PrepareSave(SnapshotType type, const std::string& file, SnapshotRoutine* cb, void *data)
     {
-        int ret = OpenWriteFile(file);
-        if (0 != ret)
+        int err = 0;
+        if (type != BACKUP_DUMP)
         {
-            return ret;
+            err = OpenWriteFile(file);
         }
+        else
+        {
+            if (!make_dir(file))
+            {
+                return -1;
+            }
+        }
+        if (0 != err)
+        {
+            return err;
+        }
+
         m_save_time = time(NULL);
         m_state = DUMPING;
         this->m_routine_cb = cb;
@@ -1787,9 +1833,17 @@ namespace ardb
         {
             ret = RedisSave();
         }
-        else
+        else if (m_type == ARDB_DUMP)
         {
             ret = ArdbSave();
+        }
+        else if (m_type == BACKUP_DUMP)
+        {
+            ret = BackupSave();
+        }
+        else
+        {
+            return ERR_NOTSUPPORTED;
         }
         Close();
         m_state = ret == 0 ? DUMP_SUCCESS : DUMP_FAIL;
@@ -1803,11 +1857,11 @@ namespace ardb
             g_lastsave = time(NULL);
             time_t end = g_lastsave;
             g_lastsave_cost = end - start;
-            INFO_LOG("Cost %us to save snapshot file with type:%s.", g_lastsave_cost, (m_type == REDIS_DUMP) ? "redis" : "ardb");
+            INFO_LOG("Cost %us to save snapshot file with type:%s.", g_lastsave_cost, type2str(m_type));
         }
         else
         {
-            WARN_LOG("Failed to save snapshot file with type:%s", (m_type == REDIS_DUMP) ? "redis" : "ardb");
+            WARN_LOG("Failed to save snapshot file with type:%s", type2str(m_type));
         }
         g_saver_num--;
         if (g_saver_num < 0)
@@ -1872,28 +1926,36 @@ namespace ardb
         return 0;
     }
 
-    int Snapshot::IsRedisDumpFile(const std::string& file)
+    SnapshotType Snapshot::GetSnapshotType(const std::string& file)
     {
+        SnapshotType invalid = (SnapshotType) -1;
+        if (is_dir_exist(file))
+        {
+            return BACKUP_DUMP;
+        }
         FILE* fp = NULL;
         if ((fp = fopen(file.c_str(), "r")) == NULL)
         {
             ERROR_LOG("Failed to load redis dump file:%s", file.c_str());
-            return -1;
+            return invalid;
         }
         char buf[10];
         if (fread(buf, 10, 1, fp) != 1)
         {
             fclose(fp);
-            return -1;
+            return invalid;
         }
         buf[9] = '\0';
         fclose(fp);
         if (memcmp(buf, "REDIS", 5) != 0)
         {
-            //WARN_LOG("Wrong signature trying to load DB from file:%s", file.c_str());
-            return 0;
+            return REDIS_DUMP;
         }
-        return 1;
+        else if (memcmp(buf, "ARDB", 4) != 0)
+        {
+            return ARDB_DUMP;
+        }
+        return invalid;
     }
 
     int Snapshot::RedisLoad()
@@ -2040,7 +2102,7 @@ namespace ardb
         g_engine->FlushAll(loadctx);
         g_engine->EndBulkLoad(loadctx);
         INFO_LOG("All data load successfully from redis snapshot file.");
-        if(g_db->GetConf().compact_after_snapshot_load)
+        if (g_db->GetConf().compact_after_snapshot_load)
         {
             g_db->CompactAll(loadctx);
         }
@@ -2092,9 +2154,10 @@ namespace ardb
                 {
                     case KEY_META:
                     {
-                        if(objectlen != 0)
+                        if (objectlen != 0)
                         {
-                            ERROR_LOG("Previous key:%s with type:%u is not complete dump, %lld missing in %lld elements", current_key.AsString().c_str(),current_keytype, objectlen, object_totallen);
+                            ERROR_LOG("Previous key:%s with type:%u is not complete dump, %lld missing in %lld elements", current_key.AsString().c_str(),
+                                    current_keytype, objectlen, object_totallen);
                             err = -2;
                             break;
                         }
@@ -2195,7 +2258,7 @@ namespace ardb
                         break;
                     }
                 }
-                if(err < 0)
+                if (err < 0)
                 {
                     break;
                 }
@@ -2217,44 +2280,6 @@ namespace ardb
         Close();
         return 0;
     }
-
-//    int Snapshot::ArdbSaveRawKeyValue(const Slice& key, const Slice& value)
-//    {
-//        BufferHelper::WriteVarSlice(m_write_buffer, key);
-//        BufferHelper::WriteVarSlice(m_write_buffer, value);
-//        if (m_write_buffer.ReadableBytes() >= 1024 * 1024)
-//        {
-//            return ArdbFlushWriteBuffer();
-//        }
-//        return 0;
-//    }
-//
-//    int Snapshot::ArdbFlushWriteBuffer()
-//    {
-//        if (m_write_buffer.Readable())
-//        {
-//            std::string compressed;
-//            snappy::Compress(m_write_buffer.GetRawReadBuffer(), m_write_buffer.ReadableBytes(), &compressed);
-//            if (compressed.size() > (m_write_buffer.ReadableBytes() + 4))
-//            {
-//                RETURN_NEGATIVE_EXPR(WriteType(ARDB_RDB_TYPE_CHUNK));
-//                uint32 len = m_write_buffer.ReadableBytes();
-//                RETURN_NEGATIVE_EXPR(WriteLen(len));
-//                RETURN_NEGATIVE_EXPR(Write(m_write_buffer.GetRawReadBuffer(), m_write_buffer.ReadableBytes()));
-//            }
-//            else
-//            {
-//                RETURN_NEGATIVE_EXPR(WriteType(ARDB_RDB_TYPE_SNAPPY_CHUNK));
-//                uint32 rawlen = m_write_buffer.ReadableBytes();
-//                RETURN_NEGATIVE_EXPR(WriteLen(rawlen));
-//                RETURN_NEGATIVE_EXPR(WriteLen(compressed.size()));
-//                RETURN_NEGATIVE_EXPR(Write(compressed.data(), compressed.size()));
-//            }
-//            m_write_buffer.Clear();
-//        }
-//        Flush();
-//        return 0;
-//    }
 
     int Snapshot::ArdbSave()
     {
@@ -2426,7 +2451,7 @@ namespace ardb
         g_engine->FlushAll(loadctx);
         g_engine->EndBulkLoad(loadctx);
         INFO_LOG("All data load successfully from ardb snapshot file.");
-        if(g_db->GetConf().compact_after_snapshot_load)
+        if (g_db->GetConf().compact_after_snapshot_load)
         {
             g_db->CompactAll(loadctx);
         }
@@ -2436,6 +2461,105 @@ namespace ardb
         g_engine->EndBulkLoad(loadctx);
         WARN_LOG("Short read or OOM loading DB. Unrecoverable error, aborting now.");
         return -1;
+    }
+
+    int Snapshot::BackupSave()
+    {
+        struct BGTask: public Thread
+        {
+                std::string path;
+                int err;
+                bool complete;
+
+                BGTask(const std::string& f) :
+                        path(f), err(0), complete(false)
+                {
+                }
+                void Run()
+                {
+                    Context dumpctx;
+                    err = g_engine->Backup(dumpctx, path);
+                    complete = true;
+                }
+        };
+        BGTask task(m_file_path);
+        task.Start();
+        while (!task.complete)
+        {
+            Thread::Sleep(100);
+            /*
+             * routine callback every 100ms
+             */
+            if (NULL != m_routine_cb)
+            {
+                int cbret = m_routine_cb(DUMPING, this, m_routine_cbdata);
+                if (0 != cbret)
+                {
+                    ERROR_LOG("Routine return error:%d or snapshot file:%s", cbret, m_file_path.c_str());
+                    break;
+                }
+                m_routinetime = get_current_epoch_millis();
+            }
+        }
+        task.Join();
+        if (0 == task.err)
+        {
+            INFO_LOG("Backup dump finished.");
+        }
+        else
+        {
+            WARN_LOG("Backup dump failed with err:%d", task.err);
+        }
+        return task.err;
+    }
+    int Snapshot::BackupLoad()
+    {
+        struct BGTask: public Thread
+        {
+                std::string path;
+                int err;
+                bool complete;
+                BGTask(const std::string& f) :
+                        path(f), err(0), complete(false)
+                {
+                }
+                void Run()
+                {
+                    Context loadctx;
+                    printf("####restore %s\n", path.c_str());
+                    err = g_engine->Restore(loadctx, path);
+                    complete = true;
+                }
+        };
+        BGTask task(m_file_path);
+        task.Start();
+        while (!task.complete)
+        {
+            Thread::Sleep(100);
+            /*
+             * routine callback every 100ms
+             */
+            if (NULL != m_routine_cb)
+            {
+                int cbret = m_routine_cb(LODING, this, m_routine_cbdata);
+                if (0 != cbret)
+                {
+                    ERROR_LOG("Routine return error:%d or snapshot file:%s", cbret, m_file_path.c_str());
+                    break;
+                }
+                m_routinetime = get_current_epoch_millis();
+            }
+        }
+        task.Join();
+        if (0 == task.err)
+        {
+            INFO_LOG("Backup restore finished.");
+        }
+        else
+        {
+            WARN_LOG("Backup restore failed with err:%d", task.err);
+        }
+        return task.err;
     }
 
     static SnapshotManager g_snapshot_manager_instance;

--- a/src/repl/rdb.cpp
+++ b/src/repl/rdb.cpp
@@ -2645,7 +2645,14 @@ namespace ardb
         Snapshot* snapshot = NULL;
         NEW(snapshot, Snapshot);
         char path[1024];
-        snprintf(path, sizeof(path) - 1, "%s/master-snapshot.%u", g_db->GetConf().backup_dir.c_str(), now);
+        if(type == BACKUP_DUMP)
+        {
+            snprintf(path, sizeof(path) - 1, "%s/master-%s-%s-%u", g_db->GetConf().backup_dir.c_str(), g_engine_name,type2str(type), now);
+        }
+        else
+        {
+            snprintf(path, sizeof(path) - 1, "%s/master-%s-snapshot.%u", g_db->GetConf().backup_dir.c_str(), type2str(type), now);
+        }
         if (0 == snapshot->BGSave(type, path, cb, data))
         {
             m_snapshots.push_back(snapshot);

--- a/src/repl/rdb.hpp
+++ b/src/repl/rdb.hpp
@@ -42,7 +42,7 @@ namespace ardb
 {
     enum SnapshotType
     {
-        REDIS_DUMP = 1, ARDB_DUMP
+        REDIS_DUMP = 1, ARDB_DUMP, BACKUP_DUMP
     };
 
     enum SnapshotState
@@ -157,42 +157,14 @@ namespace ardb
             SnapshotType m_type;
             bool Read(void* buf, size_t buflen, bool cksm);
 
-//            int WriteType(uint8 type);
-//            int WriteKeyType(KeyType type);
-//            int WriteLen(uint32 len);
-//            int WriteMillisecondTime(uint64 ts);
-//            int WriteDouble(double v);
-//            int WriteLongLongAsStringObject(long long value);
-//            int WriteRawString(const char *s, size_t len);
-//            int WriteLzfStringObject(const char *s, size_t len);
-//            int WriteTime(time_t t);
-//            int WriteStringObject(const Data& o);
-//
-//            int ReadType();
-//            time_t ReadTime();
-//            int64 ReadMillisecondTime();
-//            uint32_t ReadLen(int *isencoded);
-//            bool ReadInteger(int enctype, int64& v);
-//            bool ReadLzfStringObject(std::string& str);
-//            bool ReadString(std::string& str);
-//            int ReadDoubleValue(double&val);
-
-//            bool RedisLoadObject(Context& ctx, int type, const std::string& key, int64 expiretime);
-//            void RedisLoadListZipList(Context& ctx, unsigned char* data, const std::string& key, ValueObject& meta_value);
-//            void RedisLoadHashZipList(Context& ctx, unsigned char* data, const std::string& key, ValueObject& meta_value);
-//            void RedisLoadZSetZipList(Context& ctx, unsigned char* data, const std::string& key, ValueObject& meta_value);
-//            void RedisLoadSetIntSet(Context& ctx, unsigned char* data, const std::string& key, ValueObject& meta_value);
-//            void RedisWriteMagicHeader();
-
             int RedisLoad();
             int RedisSave();
 
-//            int ArdbWriteMagicHeader();
-//            int ArdbSaveRawKeyValue(const Slice& key, const Slice& value);
-//            int ArdbFlushWriteBuffer();
-//            int ArdbLoadBuffer(Context& ctx, Buffer& buffer);
             int ArdbSave();
             int ArdbLoad();
+
+            int BackupSave();
+            int BackupLoad();
 
             int DoSave();
             int PrepareSave(SnapshotType type, const std::string& file, SnapshotRoutine* cb, void *data);
@@ -238,7 +210,7 @@ namespace ardb
             void SetRoutineCallback(SnapshotRoutine* cb, void *data);
             ~Snapshot();
 
-            static int IsRedisDumpFile(const std::string& file);
+            static SnapshotType GetSnapshotType(const std::string& file);
     };
 
     class SnapshotManager

--- a/src/repl/slave.cpp
+++ b/src/repl/slave.cpp
@@ -457,8 +457,8 @@ OP_NAMESPACE_BEGIN
                     Buffer sync;
                     if (!m_ctx.server_is_redis)
                     {
-                        sync.Printf("psync %s %lld cksm %llu\r\n", g_repl->GetReplLog().IsReplKeySelfGen() ? "?" : g_repl->GetReplLog().GetReplKey().c_str(),
-                                g_repl->GetReplLog().WALEndOffset(), g_repl->GetReplLog().WALCksm());
+                        sync.Printf("psync %s %lld cksm %llu engine %s\r\n", g_repl->GetReplLog().IsReplKeySelfGen() ? "?" : g_repl->GetReplLog().GetReplKey().c_str(),
+                                g_repl->GetReplLog().WALEndOffset(), g_repl->GetReplLog().WALCksm(), g_engine_name);
                     }
                     else
                     {
@@ -502,7 +502,7 @@ OP_NAMESPACE_BEGIN
                     m_ctx.cached_master_runid = ss[1];
                     m_ctx.cached_master_repl_offset = offset;
                     /*
-                     * if remote master is comms, there would be a cksm part
+                     * if remote master is ardb, there would be a cksm part
                      */
                     if (ss.size() > 3)
                     {
@@ -580,8 +580,6 @@ OP_NAMESPACE_BEGIN
                 DoClose();
                 return;
             }
-//            SnapshotType snapshot_type = Snapshot::IsRedisSnapshot(m_ctx.snapshot.GetPath()) ? REDIS_SNAPSHOT : MMKV_SNAPSHOT;
-//            m_ctx.snapshot.RenameDefault();
             m_decoder.SwitchToCommandDecoder();
             m_ctx.state = SLAVE_STATE_LOADING_SNAPSHOT;
             /*

--- a/src/repl/slave.cpp
+++ b/src/repl/slave.cpp
@@ -178,7 +178,7 @@ OP_NAMESPACE_BEGIN
 
     static size_t slave_replay_wal(const void* log, size_t loglen, void* data)
     {
-        return  g_repl->GetSlave().ReplayWAL(log, loglen);
+        return g_repl->GetSlave().ReplayWAL(log, loglen);
     }
 
     void Slave::ReplayWAL()
@@ -226,7 +226,8 @@ OP_NAMESPACE_BEGIN
             int64_t after_replayed_bytes = m_ctx.sync_repl_offset - replay_init_offset;
             if (after_replayed_bytes / replay_process_events_interval_bytes > before_replayed_bytes / replay_process_events_interval_bytes)
             {
-                INFO_LOG("%lld bytes replayed from wal log, %llu bytes left.", after_replayed_bytes, g_repl->GetReplLog().WALEndOffset() - m_ctx.sync_repl_offset);
+                INFO_LOG("%lld bytes replayed from wal log, %llu bytes left.", after_replayed_bytes,
+                        g_repl->GetReplLog().WALEndOffset() - m_ctx.sync_repl_offset);
             }
             if (m_ctx.sync_repl_offset == g_repl->GetReplLog().WALEndOffset())
             {
@@ -255,7 +256,7 @@ OP_NAMESPACE_BEGIN
             {
                 break;
             }
-            if(msg.GetRawProtocolData().Readable())
+            if (msg.GetRawProtocolData().Readable())
             {
                 m_ctx.UpdateSyncOffsetCksm(msg.GetRawProtocolData());
                 m_db_writer.Put(m_ctx.ctx, msg);
@@ -457,8 +458,9 @@ OP_NAMESPACE_BEGIN
                     Buffer sync;
                     if (!m_ctx.server_is_redis)
                     {
-                        sync.Printf("psync %s %lld cksm %llu engine %s\r\n", g_repl->GetReplLog().IsReplKeySelfGen() ? "?" : g_repl->GetReplLog().GetReplKey().c_str(),
-                                g_repl->GetReplLog().WALEndOffset(), g_repl->GetReplLog().WALCksm(), g_engine_name);
+                        sync.Printf("psync %s %lld cksm %llu engine %s\r\n",
+                                g_repl->GetReplLog().IsReplKeySelfGen() ? "?" : g_repl->GetReplLog().GetReplKey().c_str(), g_repl->GetReplLog().WALEndOffset(),
+                                g_repl->GetReplLog().WALCksm(), g_engine_name);
                     }
                     else
                     {
@@ -489,7 +491,7 @@ OP_NAMESPACE_BEGIN
                 }
                 INFO_LOG("Recv psync reply:%s", reply.str.c_str());
                 std::vector<std::string> ss = split_string(reply.str, " ");
-                if (!strcasecmp(ss[0].c_str(), "FULLRESYNC"))
+                if (!strcasecmp(ss[0].c_str(), "FULLRESYNC") || !strcasecmp(ss[0].c_str(), "FULLBACKUP"))
                 {
                     int64 offset;
                     if (!string_toint64(ss[2], offset))
@@ -515,8 +517,18 @@ OP_NAMESPACE_BEGIN
                         }
                         m_ctx.cached_master_repl_cksm = cksm;
                     }
+
                     m_ctx.state = SLAVE_STATE_WAITING_SNAPSHOT;
                     m_decoder.SwitchToDumpFileDecoder();
+                    if (!strcasecmp(ss[0].c_str(), "FULLBACKUP"))
+                    {
+                        m_ctx.snapshot_path = Snapshot::GetSyncSnapshotPath(BACKUP_DUMP);
+                        std::string tmppath = m_ctx.snapshot_path + ".tmp";
+                        make_dir(tmppath);
+                        m_ctx.snapshot.SetFilePath(tmppath);
+                        INFO_LOG("[Slave]Create sync backup path:%s", tmppath.c_str());
+                        m_decoder.SwitchToBackupSyncDecoder(tmppath);
+                    }
                     break;
                 }
                 else if (!strcasecmp(ss[0].c_str(), "CONTINUE"))
@@ -548,6 +560,77 @@ OP_NAMESPACE_BEGIN
         }
     }
 
+    void Slave::LoadSyncedSnapshot()
+    {
+        m_ctx.snapshot.Close();
+        if (0 != m_ctx.snapshot.Rename(m_ctx.snapshot_path))
+        {
+            if (NULL != m_client)
+            {
+                m_client->Close();
+            }
+            return;
+        }
+        m_decoder.SwitchToCommandDecoder();
+        m_ctx.state = SLAVE_STATE_LOADING_SNAPSHOT;
+        /*
+         * set server key to a random string first, if server restart when loading data, it would do a full resync again with another server key.
+         * set wal offset&cksm to make sure that this slave could accept&save synced commands when loading snapshot file.
+         */
+        g_repl->GetReplLog().SetReplKey(random_hex_string(40));
+        g_repl->GetReplLog().ResetWALOffsetCksm(m_ctx.cached_master_repl_offset, m_ctx.cached_master_repl_cksm);
+        if (g_db->GetConf().slave_cleardb_before_fullresync)
+        {
+            g_db->FlushAll(m_ctx.ctx);
+        }
+        INFO_LOG("Start loading snapshot:%s", m_ctx.snapshot.GetPath().c_str());
+        m_ctx.cmd_recved_time = time(NULL);
+        int ret = m_ctx.snapshot.Reload(LoadRDBRoutine, &m_ctx);
+        if (0 != ret)
+        {
+            if (NULL != m_client)
+            {
+                m_client->Close();
+            }
+            WARN_LOG("Failed to load snapshot:%s", m_ctx.snapshot.GetPath().c_str());
+            return;
+        }
+        g_repl->GetReplLog().SetReplKey(m_ctx.cached_master_runid);
+        m_ctx.sync_repl_offset = m_ctx.cached_master_repl_offset;
+        m_ctx.sync_repl_cksm = m_ctx.cached_master_repl_cksm;
+        m_ctx.state = SLAVE_STATE_REPLAYING_WAL;
+        ReplayWAL();
+    }
+
+    void Slave::HandleBackupSync(Channel* ch, DirSyncStatus& status)
+    {
+        if (m_ctx.state != SLAVE_STATE_WAITING_SNAPSHOT)
+        {
+            ERROR_LOG("Invalid state:%s to handler backup sync status.", state2String(m_ctx.state));
+            ch->Close();
+            return;
+        }
+        if (status.IsItemSuccess())
+        {
+            INFO_LOG("Backup file:%s sync success.", status.path.c_str());
+        }
+        if (status.IsComplete())
+        {
+            if (status.IsSuccess())
+            {
+                INFO_LOG("Backup file:%s sync success.", status.path.c_str());
+                INFO_LOG("Backup sync success.");
+                LoadSyncedSnapshot();
+            }
+            else
+            {
+                ERROR_LOG("Failed to sync backup:%s with reason:%s", status.path.c_str(), status.reason.c_str());
+                ch->Close();
+                return;
+            }
+        }
+    }
+
     void Slave::HandleRedisDumpChunk(Channel* ch, RedisDumpFileChunk& chunk)
     {
         if (m_ctx.state != SLAVE_STATE_WAITING_SNAPSHOT)
@@ -559,11 +642,10 @@ OP_NAMESPACE_BEGIN
         if (chunk.IsFirstChunk())
         {
             m_ctx.snapshot.Close();
-            char tmp[g_db->GetConf().backup_dir.size() + 100];
-            uint32 now = time(NULL);
-            sprintf(tmp, "%s/sync-snapshot.%u.%u", g_db->GetConf().backup_dir.c_str(), getpid(), now);
-            m_ctx.snapshot.OpenWriteFile(tmp);
-            INFO_LOG("[Slave]Create dump file:%s, expected size:%lld, master is redis:%d", tmp, chunk.len, m_ctx.server_is_redis);
+            m_ctx.snapshot_path = Snapshot::GetSyncSnapshotPath(m_ctx.server_is_redis ? REDIS_DUMP : ARDB_DUMP);
+            std::string tmppath = m_ctx.snapshot_path + ".tmp";
+            m_ctx.snapshot.OpenWriteFile(tmppath);
+            INFO_LOG("[Slave]Create dump file:%s, expected size:%lld, master is redis:%d", m_ctx.snapshot_path.c_str(), chunk.len, m_ctx.server_is_redis);
             m_ctx.snapshot.SetExpectedDataSize(chunk.len);
         }
         if (!chunk.chunk.empty())
@@ -573,49 +655,7 @@ OP_NAMESPACE_BEGIN
         }
         if (chunk.IsLastChunk())
         {
-            m_ctx.snapshot.Flush();
-            if (m_ctx.snapshot.DumpLeftDataSize() > 0)
-            {
-                ERROR_LOG("Invalid synced snapshot with rest unsynced data %llu bytes", m_ctx.snapshot.DumpLeftDataSize());
-                DoClose();
-                return;
-            }
-            m_decoder.SwitchToCommandDecoder();
-            m_ctx.state = SLAVE_STATE_LOADING_SNAPSHOT;
-            /*
-             * set server key to a random string first, if server restart when loading data, it would do a full resync again with another server key.
-             * set wal offset&cksm to make sure that this slave could accept&save synced commands when loading snapshot file.
-             */
-            g_repl->GetReplLog().SetReplKey(random_hex_string(40));
-            g_repl->GetReplLog().ResetWALOffsetCksm(m_ctx.cached_master_repl_offset, m_ctx.cached_master_repl_cksm);
-            if (g_db->GetConf().slave_cleardb_before_fullresync)
-            {
-                g_db->FlushAll(m_ctx.ctx);
-            }
-            INFO_LOG("Start loading snapshot file.");
-            m_ctx.cmd_recved_time = time(NULL);
-            DBWriter load_writer;
-            m_ctx.snapshot.SetDBWriter(&load_writer);
-            int ret = m_ctx.snapshot.Reload(LoadRDBRoutine, &m_ctx);
-            m_ctx.snapshot.SetDBWriter(NULL);
-            if (0 != ret)
-            {
-                if (NULL != m_client)
-                {
-                    m_client->Close();
-                }
-                WARN_LOG("Failed to load snapshot file.");
-                return;
-            }
-            load_writer.Stop();
-            g_repl->GetReplLog().SetReplKey(m_ctx.cached_master_runid);
-            m_ctx.sync_repl_offset = m_ctx.cached_master_repl_offset;
-            m_ctx.sync_repl_cksm = m_ctx.cached_master_repl_cksm;
-            m_ctx.state = SLAVE_STATE_REPLAYING_WAL;
-            m_ctx.snapshot.Close();
-            //Disconnect all slaves when all data resynced
-            //g_repl->GetMaster().DisconnectAllSlaves();
-            ReplayWAL();
+            LoadSyncedSnapshot();
         }
     }
 
@@ -629,6 +669,10 @@ OP_NAMESPACE_BEGIN
         else if (e.GetMessage()->IsCommand())
         {
             HandleRedisCommand(ctx.GetChannel(), e.GetMessage()->command);
+        }
+        else if (e.GetMessage()->IsBackupSync())
+        {
+            HandleBackupSync(ctx.GetChannel(), e.GetMessage()->backup);
         }
         else
         {
@@ -700,7 +744,7 @@ OP_NAMESPACE_BEGIN
     }
     int64 Slave::LoadLeftBytes()
     {
-        if(m_ctx.state == SLAVE_STATE_REPLAYING_WAL)
+        if (m_ctx.state == SLAVE_STATE_REPLAYING_WAL)
         {
             return g_repl->GetReplLog().WALEndOffset() - m_ctx.sync_repl_offset;
         }
@@ -718,8 +762,7 @@ OP_NAMESPACE_BEGIN
          * if slave can serve stale data, 'SLAVE_STATE_REPLAYING_WAL' would not considered as 'loading' state.
          */
         return NULL != m_client
-                && (SLAVE_STATE_LOADING_SNAPSHOT == m_ctx.state ||
-                        (!g_db->GetConf().slave_serve_stale_data && SLAVE_STATE_REPLAYING_WAL == m_ctx.state));
+                && (SLAVE_STATE_LOADING_SNAPSHOT == m_ctx.state || (!g_db->GetConf().slave_serve_stale_data && SLAVE_STATE_REPLAYING_WAL == m_ctx.state));
     }
 
     bool Slave::IsConnected()

--- a/src/repl/snapshot.hpp
+++ b/src/repl/snapshot.hpp
@@ -168,6 +168,7 @@ namespace ardb
 
             int DoSave();
             int PrepareSave(SnapshotType type, const std::string& file, SnapshotRoutine* cb, void *data);
+            void VerifyState();
         public:
             Snapshot();
             SnapshotType GetType()
@@ -190,8 +191,8 @@ namespace ardb
             {
                 return m_save_time;
             }
-            bool IsSaving() const;
-            bool IsReady() const;
+            bool IsSaving();
+            bool IsReady();
             void SetExpectedDataSize(int64 size);
             int64 DumpLeftDataSize();
             int64 ProcessLeftDataSize();

--- a/src/repl/snapshot.hpp
+++ b/src/repl/snapshot.hpp
@@ -27,8 +27,8 @@
  *THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RDB_HPP_
-#define RDB_HPP_
+#ifndef SNAPSHOT_HPP_
+#define SNAPSHOT_HPP_
 #include <string>
 #include <deque>
 #include "common.hpp"
@@ -198,6 +198,7 @@ namespace ardb
             int Write(const void* buf, size_t buflen);
             int OpenWriteFile(const std::string& file);
             int OpenReadFile(const std::string& file);
+            int SetFilePath(const std::string& path);
             int Load(const std::string& file, SnapshotRoutine* cb, void *data);
             int Reload(SnapshotRoutine* cb, void *data);
             int Save(SnapshotType type, const std::string& file, SnapshotRoutine* cb, void *data);
@@ -211,6 +212,8 @@ namespace ardb
             ~Snapshot();
 
             static SnapshotType GetSnapshotType(const std::string& file);
+            static SnapshotType GetSnapshotTypeByName(const std::string& name);
+            static std::string GetSyncSnapshotPath(SnapshotType type);
     };
 
     class SnapshotManager


### PR DESCRIPTION
The new snapshot type 'backup' is much faster than 'redis'/'ardb' type for both save & load action，but  it's storage engine related. Only rocksdb's backup can be restore by server with rocksdb engine.  