### PR TITLE
Fix for transaction QUEUED reply sent as QUEUE

### DIFF
--- a/src/common/channel/codec/redis_reply.cpp
+++ b/src/common/channel/codec/redis_reply.cpp
@@ -229,7 +229,7 @@ namespace ardb
                 }
                 case STATUS_QUEUED:
                 {
-                    str.assign("QUEUED", 5);
+                    str.assign("QUEUED", 6);
                     break;
                 }
                 case STATUS_NOKEY:


### PR DESCRIPTION
This fixes transaction reply is being sent as QUEUE instead of QUEUED which can break many redis client implementation. (ex: php_redis )