### PR TITLE
Selecting RocksDB compaction strategies

### DIFF
--- a/ardb.conf
+++ b/ardb.conf
@@ -40,8 +40,20 @@ server[0].listen              0.0.0.0:16379
 qps-limit-per-host                  0
 qps-limit-per-connection            0
 
-#rocksdb's options 
-rocksdb.options               write_buffer_size=512M;max_write_buffer_number=5;min_write_buffer_number_to_merge=2;compression=kSnappyCompression;\
+# Specify the optimized RocksDB compaction strategies.
+# If anything other than none is set then the rocksdb.options will not be used.
+# The property can one of:
+# OptimizeLevelStyleCompaction
+# OptimizeUniversalStyleCompaction
+# none
+#
+rocksdb.compaction         none
+
+# Enable this to indicate that hsca/sscan/zscan command use total order mode for rocksdb engine
+rocksdb.scan-total-order              false
+
+#rocksdb's options
+rocksdb.options               write_buffer_size=512M;max_write_buffer_number=5;min_write_buffer_number_to_merge=3;compression=kSnappyCompression;\
                               bloom_locality=1;memtable_prefix_bloom_size_ratio=0.1;\
                               block_based_table_factory={block_cache=512M;filter_policy=bloomfilter:10:true};\
                               create_if_missing=true;max_open_files=10000;rate_limiter_bytes_per_sec=50M
@@ -429,25 +441,22 @@ hll-sparse-max-bytes 3000
 #trusted-ip  10.10.10.10
 #trusted-ip  10.10.10.*
 
+# By default Ardb would not compact whole db after loading a snapshot, which may happens
+# when slave syncing from master, processing 'import' command from client.
+# This configuration only works with rocksdb engine.
+# If ardb dord not compact data after loading snapshot file, there would be poor read performance before rocksdb
+# completes the next compaction task internally. While the compaction task would cost very long time for a huge data set. 
+compact-after-snapshot-load  false
 
 # Ardb would store cursor in memory 
 scan-redis-compatible         yes
 scan-cursor-expire-after      60
-
-#Enable this to indicate that hsca/sscan/zscan command use total order mode for rocksdb engine
-scan-total-order              no
 
 redis-compatible-mode     no
 redis-compatible-version  2.8.0
 
 statistics-log-period     600
 
-# By default Ardb would not compact whole db after loading a snapshot, which may happens
-# when slave syncing from master, processing 'import' command from client.
-# This configuration only works with rocksdb engine.
-# If ardb do not compact data after loading snapshot file, there would be poor read performance before rocksdb
-# compelete next compact task internally. While the compact task would cost very long time for a huge data set. 
-compact-after-snapshot-load  false
 
 # Range deletion min size trigger 
 range-delete-min-size  100

--- a/src/command/keys.cpp
+++ b/src/command/keys.cpp
@@ -188,7 +188,7 @@ OP_NAMESPACE_BEGIN
         bool skip_first = false;
         Data nil;
 
-        if (GetConf().scan_total_order)
+        if (GetConf().rocksdb_scan_total_order)
         {
             ctx.flags.iterate_total_order = 1;
         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -146,6 +146,12 @@ OP_NAMESPACE_BEGIN
             lp.port = 16379;
             servers.push_back(lp);
         }
+        if (strcasecmp(engine.c_str(), "rocksdb") == 0)
+        {
+            conf_get_string(props, "rocksdb.compaction", rocksdb_compaction);
+            conf_get_bool(props, "rocksdb.scan-total-order", rocksdb_scan_total_order);
+        }
+
         conf_get_string(props, "engine", engine);
         conf_get_string(props, "data-dir", data_base_path);
         conf_get_string(props, "backup-dir", backup_dir);
@@ -287,7 +293,6 @@ OP_NAMESPACE_BEGIN
         conf_get_int64(props, "qps-limit-per-host", qps_limit_per_host);
         conf_get_int64(props, "qps-limit-per-connection", qps_limit_per_connection);
         conf_get_int64(props, "range-delete-min-size", range_delete_min_size);
-        conf_get_bool(props, "scan-total-order", scan_total_order);
 
         //trusted_ip.clear();
         Properties::const_iterator ip_it = props.find("trusted-ip");

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -78,6 +78,10 @@ OP_NAMESPACE_BEGIN
             int64 slowlog_log_slower_than;
             int64 slowlog_max_len;
 
+            // rocksdb specific properties
+            std::string rocksdb_compaction;
+            bool rocksdb_scan_total_order;
+
             std::string repl_data_dir;
             std::string backup_dir;
             bool backup_redis_format;
@@ -130,20 +134,19 @@ OP_NAMESPACE_BEGIN
 
             bool scan_redis_compatible;
             int64 scan_cursor_expire_after;
-            bool scan_total_order;
+
 
             int64 snapshot_max_lag_offset;
             int64 maxsnapshots;
 
             bool redis_compatible;
+            bool compact_after_snapshot_load;
 
             std::string masterauth;
 
             std::string redis_compatible_version;
 
             int64 statistics_log_period;
-
-            bool compact_after_snapshot_load;
 
             int64 qps_limit_per_host;
             int64 qps_limit_per_connection;
@@ -156,18 +159,19 @@ OP_NAMESPACE_BEGIN
 
             ArdbConfig() :
                     daemonize(false), thread_pool_size(0), hz(10), max_clients(10000), tcp_keepalive(0), timeout(0), engine(
-                            "rocksdb"), slowlog_log_slower_than(10000), slowlog_max_len(128), repl_data_dir("./repl"), backup_dir(
-                            "./backup"), backup_redis_format(false), repl_ping_slave_period(10), repl_timeout(60), repl_backlog_size(
-                            100 * 1024 * 1024), repl_backlog_cache_size(100 * 1024 * 1024), repl_backlog_sync_period(1), repl_backlog_time_limit(
+                            "rocksdb"),rocksdb_scan_total_order(false), rocksdb_compaction("none"), slowlog_log_slower_than(10000),
+							slowlog_max_len(128), repl_data_dir("./repl"), backup_dir("./backup"), backup_redis_format(false),
+							repl_ping_slave_period(10), repl_timeout(60), repl_backlog_size(100 * 1024 * 1024),
+							repl_backlog_cache_size(100 * 1024 * 1024), repl_backlog_sync_period(1), repl_backlog_time_limit(
                             3600), repl_min_slaves_to_write(0), repl_min_slaves_max_lag(10), repl_serve_stale_data(
                             false), slave_cleardb_before_fullresync(true), slave_readonly(true), slave_serve_stale_data(
                             true), slave_priority(100), max_slave_worker_queue(1024), lua_time_limit(0), master_port(0), loglevel(
                             "INFO"), hll_sparse_max_bytes(3000), reply_pool_size(10000), slave_client_output_buffer_limit(
                             256 * 1024 * 1024), pubsub_client_output_buffer_limit(32 * 1024 * 1024), slave_ignore_expire(
                             false), slave_ignore_del(false), repl_disable_tcp_nodelay(true), scan_redis_compatible(
-                            true), scan_cursor_expire_after(60), scan_total_order(false),snapshot_max_lag_offset(500 * 1024 * 1024), maxsnapshots(
-                            10), redis_compatible(false), redis_compatible_version("2.8.0"), statistics_log_period(300), compact_after_snapshot_load(
-                            false), qps_limit_per_host(0), qps_limit_per_connection(0), range_delete_min_size(100)
+                            true), scan_cursor_expire_after(60), snapshot_max_lag_offset(500 * 1024 * 1024), maxsnapshots(
+                            10), compact_after_snapshot_load(false), redis_compatible(false), redis_compatible_version("2.8.0"),
+							statistics_log_period(300), qps_limit_per_host(0), qps_limit_per_connection(0), range_delete_min_size(100)
             {
             }
             bool Parse(const Properties& props);

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -35,6 +35,8 @@
 #include "thread/lock_guard.hpp"
 #include "thread/spin_mutex_lock.hpp"
 #include "db/db.hpp"
+#include "util/string_helper.hpp"
+
 
 OP_NAMESPACE_BEGIN
 
@@ -810,7 +812,14 @@ OP_NAMESPACE_BEGIN
             ERROR_LOG("Invalid rocksdb's options:%s with error reason:%s", conf.c_str(), s.ToString().c_str());
             return -1;
         }
-        m_options.OptimizeLevelStyleCompaction();
+        if(strcasecmp(g_db->GetConf().rocksdb_compaction.c_str(),"OptimizeLevelStyleCompaction")==0 )
+        {
+            m_options.OptimizeLevelStyleCompaction();
+
+        } else if (strcasecmp(g_db->GetConf().rocksdb_compaction.c_str(),"OptimizeUniversalStyleCompaction")==0 ) {
+        	m_options.OptimizeUniversalStyleCompaction();
+        }
+
         m_options.IncreaseParallelism();
         m_options.stats_dump_period_sec = (unsigned int) g_db->GetConf().statistics_log_period;
         m_dbdir = dir;

--- a/test/ardb-test.conf
+++ b/test/ardb-test.conf
@@ -31,6 +31,18 @@ pidfile ${ARDB_HOME}/ardb.pid
 #server[1].unixsocketperm     755
 #server[1].qps-limit          1000
 
+# Specify the optimized RocksDB compaction strategies.
+# If anything other than none is set then the rocksdb.options will not be used.
+# The property can one of:
+# OptimizeLevelStyleCompaction
+# OptimizeUniversalStyleCompaction
+# none
+#
+rocksdb.compaction         none
+
+# Enable this to indicate that hsca/sscan/zscan command use total order mode for rocksdb engine
+rocksdb.scan-total-order              false
+
 #rocksdb's options 
 rocksdb.options               write_buffer_size=512M;max_write_buffer_number=5;min_write_buffer_number_to_merge=2;compression=kSnappyCompression;\
                               bloom_locality=1;memtable_prefix_bloom_bits=100000000;memtable_prefix_bloom_probes=6;\


### PR DESCRIPTION
* RocksDB allows for `OptimizeLevelStyleCompaction` and `OptimizeUniversalStyleCompaction`.  Adding the ability for both to be used.
* Currently ARDB, overrides all provided RocksDB options by issuing `OptimizeLevelStyleCompaction`. Allowing for a user to select `none` such that the RocksDB configurations make sense.
* Organizing RocksDB configurations.