### PR TITLE
making WAL optionable and disabling it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - clang
 
 sudo: required
-dist: trusty
+dist: xenial
 
 addons:
     packages:

--- a/ardb.conf
+++ b/ardb.conf
@@ -47,10 +47,15 @@ qps-limit-per-connection            0
 # OptimizeUniversalStyleCompaction
 # none
 #
-rocksdb.compaction         none
+rocksdb.compaction           OptimizeLevelStyleCompaction
 
 # Enable this to indicate that hsca/sscan/zscan command use total order mode for rocksdb engine
 rocksdb.scan-total-order              false
+
+# Disable RocksDB WAL may improve the write performance but
+# data in the un-flushed memtables might be lost in case of a RocksDB shutdown.
+# Disabling WAL provides similar guarantees as Redis.
+rocksdb.disableWAL            true
 
 #rocksdb's options
 rocksdb.options               write_buffer_size=512M;max_write_buffer_number=5;min_write_buffer_number_to_merge=3;compression=kSnappyCompression;\

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -149,6 +149,7 @@ OP_NAMESPACE_BEGIN
         if (strcasecmp(engine.c_str(), "rocksdb") == 0)
         {
             conf_get_string(props, "rocksdb.compaction", rocksdb_compaction);
+            conf_get_bool(props, "rocksdb.disableWAL", rocksdb_disablewal);
             conf_get_bool(props, "rocksdb.scan-total-order", rocksdb_scan_total_order);
         }
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -81,6 +81,7 @@ OP_NAMESPACE_BEGIN
             // rocksdb specific properties
             std::string rocksdb_compaction;
             bool rocksdb_scan_total_order;
+            bool rocksdb_disablewal;
 
             std::string repl_data_dir;
             std::string backup_dir;

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -820,6 +820,12 @@ OP_NAMESPACE_BEGIN
         	m_options.OptimizeUniversalStyleCompaction();
         }
 
+        if(g_db->GetConf().rocksdb_disablewal)
+        {
+            disablewal=true;
+        }
+
+
         m_options.IncreaseParallelism();
         m_options.stats_dump_period_sec = (unsigned int) g_db->GetConf().statistics_log_period;
         m_dbdir = dir;
@@ -871,7 +877,7 @@ OP_NAMESPACE_BEGIN
         }
         RocksDBLocalContext& rocks_ctx = g_rocks_context.GetValue();
         rocksdb::WriteOptions opt;
-        if (ctx.flags.bulk_loading)
+        if (disablewal || ctx.flags.bulk_loading)
         {
             opt.disableWAL = true;
         }
@@ -901,7 +907,7 @@ OP_NAMESPACE_BEGIN
         }
         RocksDBLocalContext& rocks_ctx = g_rocks_context.GetValue();
         rocksdb::WriteOptions opt;
-        if (ctx.flags.bulk_loading)
+        if (disablewal || ctx.flags.bulk_loading)
         {
             opt.disableWAL = true;
         }
@@ -1187,7 +1193,7 @@ OP_NAMESPACE_BEGIN
         if (rocks_ctx.transc.ReleaseRef(false) == 0)
         {
             rocksdb::WriteOptions opt;
-            if (ctx.flags.bulk_loading)
+            if (disablewal || ctx.flags.bulk_loading)
             {
                 opt.disableWAL = true;
             }

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -109,7 +109,7 @@ OP_NAMESPACE_BEGIN
                             false), delete_after_finish(false)
             {
             }
-            bool EqaulOptions(const rocksdb::ReadOptions& a)
+            bool EqualOptions(const rocksdb::ReadOptions& a)
             {
                 return a.total_order_seek == iter_total_order_seek
                         && a.prefix_same_as_start == iter_prefix_same_as_start;

--- a/src/db/rocksdb/rocksdb_engine.hpp
+++ b/src/db/rocksdb/rocksdb_engine.hpp
@@ -108,6 +108,7 @@ OP_NAMESPACE_BEGIN
             SpinRWLock m_lock;
             ThreadMutex m_backup_lock;
             bool m_bulk_loading;
+            bool disablewal;
 
             ColumnFamilyHandlePtr GetColumnFamilyHandle(Context& ctx, const Data& name, bool create_if_noexist);
 


### PR DESCRIPTION
* Default option for compactions should be `OptimizeLevelStyleCompaction` for backward compatibility.
* Adding an option to enable/disable WAL. WAL is needed for transactions and disabling RocksDB WAL for writes provides similar guarantees as Redis (if the process dies in memory data (uncommitted memtables are lost). In fact currently the [WAL Recovery Modes](https://github.com/facebook/rocksdb/wiki/WAL-Recovery-Modes) is not being used.
* Disabling WAL has increased the SET throughput in my tests with 1KB payload 30% (empty DB)-300%.