### PR TITLE
Bug fix: UnlockKeys() should return lock once ?

### DIFF
--- a/src/command/t_zset.cpp
+++ b/src/command/t_zset.cpp
@@ -91,11 +91,6 @@ OP_NAMESPACE_BEGIN
             reply.SetErrorReason("INCR option supports a single increment-element pair");
             return 0;
         }
-        if (incr && elements > 1)
-        {
-            reply.SetErrorReason("INCR option supports a single increment-element pair");
-            return 0;
-        }
         std::vector<double> scores;
         for (size_t i = 0; i < elements; i++)
         {

--- a/src/db/codec.cpp
+++ b/src/db/codec.cpp
@@ -431,23 +431,15 @@ OP_NAMESPACE_BEGIN
             vals.resize(2);
             replaced = true;
         }
-        if (GetMin().IsNil() && GetMax().IsNil())
+        if (GetMin().IsNil() || GetMin() > v)
         {
             GetMin() = v;
-            GetMax() = v;
+            replaced = true;
         }
-        else
+        if (GetMax().IsNil() || GetMax() < v)
         {
-            if (GetMin() > v || GetMin().IsNil())
-            {
-                GetMin() = v;
-                replaced = true;
-            }
-            if (GetMax() < v)
-            {
-                GetMax() = v;
-                replaced = true;
-            }
+            GetMax() = v;
+            replaced = true;
         }
         return replaced;
     }

--- a/src/db/db.cpp
+++ b/src/db/db.cpp
@@ -851,11 +851,11 @@ OP_NAMESPACE_BEGIN
             {
                 lock = ret->second;
                 m_locking_keys.erase(ret);
-                m_lock_pool.push(lock);
             }
         }
         if (NULL != lock)
         {
+            m_lock_pool.push(lock);
             LockGuard<ThreadMutexLock> guard(*lock);
             lock->Notify();
         }

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -1489,13 +1489,9 @@ OP_NAMESPACE_BEGIN
             {
                 m_rocks_iter->SeekToLast();
             }
-            if (m_rocks_iter->Valid())
+            else
             {
-
-                if (!Valid())
-                {
-                    Prev();
-                }
+                Prev();
             }
         }
         else

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -1550,7 +1550,7 @@ OP_NAMESPACE_BEGIN
     }
     RocksDBIterator::~RocksDBIterator()
     {
-        if (NULL != m_iter)
+        if (NULL != m_rocks_iter)
         {
             DELETE(m_iter);
             //g_iter_cache.Recycle(m_iter);

--- a/src/db/rocksdb/rocksdb_engine.cpp
+++ b/src/db/rocksdb/rocksdb_engine.cpp
@@ -1541,7 +1541,7 @@ OP_NAMESPACE_BEGIN
     }
     void RocksDBIterator::Del()
     {
-        if (NULL != m_iter)
+        if (NULL != m_rocks_iter)
         {
             rocksdb::WriteOptions opt;
             m_engine->m_db->Delete(opt, m_cf, m_rocks_iter->key());
@@ -1550,7 +1550,7 @@ OP_NAMESPACE_BEGIN
     }
     RocksDBIterator::~RocksDBIterator()
     {
-        if (NULL != m_rocks_iter)
+        if (NULL != m_iter)
         {
             DELETE(m_iter);
             //g_iter_cache.Recycle(m_iter);


### PR DESCRIPTION
As multikeys share the same lock, once released, such lock should be pushed to lock_pool once rather than N times.
Thought should be worked this way, correct me if i'm wrong.

One more question, as ardb uses single thread to handle user requests, what's ```KeyLockGuards``` used for, like in t_hash.cpp, race with repl's threads ?

Thanks.