### PR TITLE
Fix ping command

### DIFF
--- a/src/command/connection.cpp
+++ b/src/command/connection.cpp
@@ -37,7 +37,7 @@ OP_NAMESPACE_BEGIN
     }
     int Ardb::Ping(Context& ctx, RedisCommandFrame& cmd)
     {
-    	if(cmd.GetArguments().size() == 1)
+    	if(cmd.GetArguments().size() == 0)
     	{
             ctx.GetReply().SetStatusCode(STATUS_PONG);
     	}


### PR DESCRIPTION
The ping command checked for the wrong number of arguments before... causing ardb to crash whenever pinged. See expected behavior:
https://redis.io/commands/ping