### PR TITLE
Increase DBWriter dequeue lock timeout to 1000ms

### DIFF
--- a/src/db/db_utils.cpp
+++ b/src/db/db_utils.cpp
@@ -95,7 +95,7 @@ OP_NAMESPACE_BEGIN
             {
                 while (running)
                 {
-                    RedisCommandFrame* cmd = writer->Dequeue(1);
+                    RedisCommandFrame* cmd = writer->Dequeue(1000);
                     if(NULL != cmd)
                     {
                         Call(*cmd);


### PR DESCRIPTION
The old timeout is 1ms, this cause ardb keep consuming CPU (about 10%), increase timeout to 1000ms solved this problem.