### PR TITLE
fix segmentation fault when maxclients is reached

### DIFF
--- a/src/command/blocked.cpp
+++ b/src/command/blocked.cpp
@@ -94,7 +94,14 @@ OP_NAMESPACE_BEGIN
             }
             ctx.ClearBPop();
         }
-        ctx.client->client->UnblockRead();
+        if (ctx.client->client != nullptr)
+        {
+            // Apart from BRPOP and friends, this is usually called in
+            // ARDB::FreeClient, which is usually called when a channel is
+            // closed. But there's no guarantee a channel is set up already, for
+            // example when a channel is closed because accept() failed.
+            ctx.client->client->UnblockRead();
+        }
         return 0;
     }
 


### PR DESCRIPTION
When maxclients is reached, and another client connects,
```
void SocketChannel::OnAccepted()
{
    if (aeCreateFileEvent(GetService().GetRawEventLoop(), m_fd, AE_READABLE, Channel::IOEventCallback, this) == AE_ERR)
    {
        int err = errno;
        ERROR_LOG("Failed to add event for accepted client for fd:%d for reason:%s", m_fd, strerror(err));
        Close();
        return;
    }
    m_detached = false;
    m_state = SOCK_CONNECTED;
    fire_channel_open(this);
    fire_channel_connected(this);

    //INFO_LOG("Accepted on tid:%d", Thread::CurrentThreadID());
}
```
`aeCreateFileEvent` here will return `AE_ERR`, and `Close()` is immediately called. Eventually `ARDB::FreeClient` is called, which in turn calls `UnblockKeys(ctx, true, NULL);`, and we step into this function. But because a connection is never set up, `ctx.client->client` is a null pointer, so it'll crash with a segmentation fault. Fixing this allows connections to be closed graciously in the event maxclients is reached.