### PR TITLE
Change MERCATOR_MAX to right value.

### DIFF
--- a/src/common/geo/geohash_helper.cpp
+++ b/src/common/geo/geohash_helper.cpp
@@ -47,7 +47,7 @@ namespace ardb
     /// @brief Earth's quatratic mean radius for WGS-84
     static const double EARTH_RADIUS_IN_METERS = 6372797.560856;
 
-    static const double MERCATOR_MAX = 20037726.37;
+    static const double MERCATOR_MAX = 20020734.00;
     //static const double MERCATOR_MIN = -20037726.37;
 
     static inline double deg_rad(double ang)


### PR DESCRIPTION
MERCATOR_MAX should be M_PI*R. When R is 6372797.560856, the MERCATOR_MAX is 20020734.00.